### PR TITLE
Add GitHub Actions workflow to build and push Docker image

### DIFF
--- a/.github/workflows/furniturestore.yml
+++ b/.github/workflows/furniturestore.yml
@@ -1,0 +1,34 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v2
+      with:
+        java-version: '21'
+
+    - name: Build with Maven
+      run: mvn clean package
+
+    - name: Build Docker image
+      run: docker build -t tjouve/furniturestore:${{ github.ref_name }} .
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Push Docker image
+      run: docker push tjouve/furniturestore:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ WORKDIR /app
 RUN keytool -import -alias zscaler -cacerts -storepass changeit -file zscaler.pem -noprompt
 RUN mvn package
 
-FROM openjdk:25-jdk-bullseye
+FROM openjdk:21-jdk-bullseye
 
 COPY --from=builder /app/target/*.jar app.jar
 
 CMD java $JAVA_OPTS $KS_OPTS $AGENT_OPTS $MEM_OPTS -jar app.jar $SPRING_OPTS
 EXPOSE 9098
-

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sopra.opel</groupId>
 	<artifactId>furniturestore</artifactId>
-	<version>1.0.0</version>
+	<version>${env.GITHUB_REF_NAME}</version>
 	<name>furniturestore</name>
 	<description>Furniture Store</description>
 


### PR DESCRIPTION
Add GitHub Actions workflow to build Maven project, generate Docker image, and push to Docker Hub on tag creation.

* **Dockerfile**
  - Update base image to `openjdk:21-jdk-bullseye`.

* **.github/workflows/furniturestore.yml**
  - Create new workflow file to build Maven project, generate Docker image, and push to Docker Hub.
  - Define workflow to trigger on tag creation.
  - Add steps to check out repository, set up Java, build Maven project, build Docker image, and push to Docker Hub.

* **pom.xml**
  - Update `<version>` tag to use the branch/tag name.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomtalks/furniturestore/pull/1?shareId=280c1d92-c527-450d-981a-e80f9b7f4a1b).